### PR TITLE
fix: 자동 재생 종료 예정 시간 버그 수정

### DIFF
--- a/src/popover/player/components/PlayerPopoverContent.tsx
+++ b/src/popover/player/components/PlayerPopoverContent.tsx
@@ -33,9 +33,9 @@ export default function PlayerPopoverContent({ isPopoverOpen, isPlaying, setIsPl
     return 0;
   };
 
-  const totalDurationSeconds = useMemo(() => {
-    return vods.reduce((sum, vod) => sum + parseTimeToSeconds(vod.length), 0);
-  }, [vods]);
+  const remainingDurationSeconds = useMemo(() => {
+    return vods.slice(currentVideoIndex).reduce((sum, vod) => sum + parseTimeToSeconds(vod.length), 0);
+  }, [vods, currentVideoIndex]);
 
   const formatExpectedEndTime = (seconds: number): string => {
     const endTime = new Date(Date.now() + seconds * 1000);
@@ -140,7 +140,7 @@ export default function PlayerPopoverContent({ isPopoverOpen, isPlaying, setIsPl
     isHover && isPlaying
       ? t('stopWatching')
       : isPlaying
-        ? t('expectedEnd', { time: formatExpectedEndTime(totalDurationSeconds) })
+        ? t('expectedEnd', { time: formatExpectedEndTime(remainingDurationSeconds) })
         : isDone
           ? t('doneWatching')
           : t('startWatching');


### PR DESCRIPTION
## Summary
- 자동 재생 플레이어에서 영상이 변경될 때 종료 예정 시간이 뒤로 밀리는 버그 수정
- `totalDurationSeconds` (전체 영상 합산) → `remainingDurationSeconds` (현재 영상 이후만 합산)으로 변경

## 원인
`formatExpectedEndTime`이 `Date.now() + 전체 영상 길이`로 계산하고 있어서, 영상이 넘어가면 `Date.now()`는 증가하지만 전체 영상 길이는 줄어들지 않아 종료 시간이 계속 밀림

## Test plan
- [x] 자동 재생 시작 시 종료 예정 시간 확인
- [x] 영상이 넘어갈 때 종료 예정 시간이 뒤로 밀리지 않는지 확인
- [x] 드래그로 영상 순서 변경 후에도 정상 동작 확인