### PR TITLE
fix: pr-autolabel 타입 미검출 시 기존 라벨 보존

### DIFF
--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -43,6 +43,12 @@ jobs:
             });
             const currentNames = current.map((l) => l.name);
 
+            // 타입을 못 찾으면 라벨을 건드리지 않는다 (기존 라벨 보존)
+            if (!target) {
+              core.info(`제목에서 타입을 못 찾음: "${title}" — 라벨 변경 없음`);
+              return;
+            }
+
             // 관리 대상(타입) 라벨 중 target이 아닌 것 제거
             for (const name of currentNames) {
               if (MANAGED.has(name) && name !== target) {
@@ -53,11 +59,6 @@ jobs:
                   name,
                 });
               }
-            }
-
-            if (!target) {
-              core.info(`제목에서 타입을 못 찾음: "${title}" — 라벨 변경 없음`);
-              return;
             }
             if (!currentNames.includes(target)) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
Closes #89

## 변경 내용
PR 제목에 Conventional 타입 prefix가 없을 때 기존 타입 라벨이 삭제되던 버그 수정 — `if (!target) return`을 제거 루프 앞으로 이동해 라벨을 보존.

CodeRabbit #86 리뷰 반영.

## 변경 유형
- [x] 🐛 버그 수정

## 체크리스트
- [x] 연결 이슈 (#89)
- [x] YAML 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* PR 자동 라벨 지정 워크플로우의 라벨 동기화 로직을 개선하여 중복 라벨 추가를 방지하고 기존 라벨 보존을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->