### PR TITLE
ci: release-please PR이 CI/CodeRabbit에서 깨끗이 통과하도록 정리

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,9 @@ reviews:
     enabled: true # PR 최초 생성 시 자동 리뷰
     auto_incremental_review: false # 이후 push에는 자동 재리뷰 안 함 (수동 `@coderabbitai review`)
     drafts: false
+    # release-please가 자동 생성하는 Release PR은 리뷰하지 않는다 (리뷰할 코드 없음)
+    ignore_title_keywords:
+      - release
     base_branches:
       - main
   path_filters:

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ coverage
 
 *.log
 *.lock
+
+# release-please가 포맷을 소유 (prettier 검사 제외)
+CHANGELOG.md


### PR DESCRIPTION
Closes #97

## 변경 내용
- `.prettierignore`에 `CHANGELOG.md` 추가 — release-please가 생성하는 CHANGELOG가 prettier 검사에서 실패하던 문제 해소 (Release PR #96의 `verify` 실패 원인)
- `.coderabbit.yaml`에 `ignore_title_keywords: [release]` — 자동 생성 Release PR은 CodeRabbit 리뷰 제외

## 변경 유형
- [x] ⚙️ 빌드/CI

## 체크리스트
- [x] 연결 이슈 (#97)
- [x] YAML 검증

## 머지 후
release-please가 #96을 새 main 기준으로 갱신하면 `verify`가 통과하고 CodeRabbit 리뷰도 안 달림.